### PR TITLE
Fix the SHA3 instruction gas calculation.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1846,7 +1846,7 @@ C_\text{\tiny CALL}(\boldsymbol{\sigma}, \boldsymbol{\mu}) & \text{if} \quad w =
 &\quad\text{\small DELEGATECALL} \\
 C_\text{\tiny SELFDESTRUCT}(\boldsymbol{\sigma}, \boldsymbol{\mu}) & \text{if} \quad w = \text{\small SELFDESTRUCT} \\
 G_{create} & \text{if} \quad w = \text{\small CREATE}\\
-G_{sha3}+G_{sha3word} \lceil \mathbf{s}[1] \div 32 \rceil & \text{if} \quad w = \text{\small SHA3}\\
+G_{sha3}+G_{sha3word}\times\lceil \boldsymbol{\mu}_{\mathbf{s}}[1] \div 32 \rceil & \text{if} \quad w = \text{\small SHA3}\\
 G_{jumpdest} & \text{if} \quad w = \text{\small JUMPDEST}\\
 G_{sload} & \text{if} \quad w = \text{\small SLOAD}\\
 G_{zero} & \text{if} \quad w \in W_{zero}\\


### PR DESCRIPTION
The description of <code>G<sub>sha3word</sub></code> is :
> Paid for each word (rounded up) for input data to a SHA3 operation.

According to the description of the `SHA3` instruction, we know that the second parameter in the stack <code>μ<sub>s</sub>[1]</code> is the number of words of the input data.
![image](https://user-images.githubusercontent.com/4555304/66584828-686d1580-ebb8-11e9-93af-e74b69e285e2.png)

So, <code>G<sub>sha3word</sub></code> just a simple multiplication calculation.

This changes the following
![image](https://user-images.githubusercontent.com/4555304/66586025-82a7f300-ebba-11e9-8a89-c1d632675e13.png)
to
![image](https://user-images.githubusercontent.com/4555304/66586066-97848680-ebba-11e9-8d34-a808901d0452.png)
